### PR TITLE
Add Markowitz backtest notebook

### DIFF
--- a/notebooks/markowitz/01_backtest_markowitz.ipynb
+++ b/notebooks/markowitz/01_backtest_markowitz.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, pathlib\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import joblib\n",
+    "\n",
+    "PROJECT_ROOT = pathlib.Path().resolve().parents[1]\n",
+    "if str(PROJECT_ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(PROJECT_ROOT))\n",
+    "\n",
+    "from src import config as cfg\n",
+    "import src.evol_utils as eu\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cargar precios y calcular retornos diarios\n",
+    "df_prices = pd.read_parquet(cfg.DATA / 'raw' / 'prices.parquet').sort_index()\n",
+    "df_ret = np.log(df_prices / df_prices.shift(1)).dropna()\n",
+    "print('\u2705 Datos cargados:', df_ret.shape)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rebalancear_markowitz(fecha, df_ret, w_prev=None):\n",
+    "    idx = df_ret.index.get_loc(fecha)\n",
+    "    ventana = df_ret.iloc[idx-cfg.WINDOW: idx]\n",
+    "    mu_hat = ventana.mean().values\n",
+    "    Sigma = ventana.cov().values\n",
+    "    res = eu.resolver_optimizacion(mu_hat, Sigma, w_prev=w_prev)\n",
+    "    w_star = eu.elegir_w_star(res, mu_hat, Sigma, w_prev=w_prev)\n",
+    "    diarios = df_ret.iloc[idx: idx+cfg.REBAL_FREQ].dot(w_star)\n",
+    "    return w_star, diarios\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fechas = df_ret.loc[cfg.START_BACKTEST:].index\n",
+    "w_prev = None\n",
+    "series = []\n",
+    "for i in range(cfg.WINDOW, len(fechas)-cfg.REBAL_FREQ, cfg.REBAL_FREQ):\n",
+    "    fecha = fechas[i]\n",
+    "    w_prev, ret_d = rebalancear_markowitz(fecha, df_ret, w_prev)\n",
+    "    series.append(ret_d)\n",
+    "    print(f'\u2705 {fecha.date()} | {len(ret_d)} d\u00edas')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "serie = pd.concat(series)\n",
+    "joblib.dump(serie, cfg.RESULT / 'backtest_markowitz.pkl')\n",
+    "print('\u2705 Serie guardada:', cfg.RESULT / 'backtest_markowitz.pkl')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebook to run a simple Markowitz backtest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c43e340a48325a3fcef3e1134887d