### PR TITLE
Add ridge regression model training and inference

### DIFF
--- a/notebooks/ridge/02_train_ridge.ipynb
+++ b/notebooks/ridge/02_train_ridge.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Entrenamiento Ridge"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import sys, pathlib\nimport pandas as pd\nimport joblib\nfrom sklearn.linear_model import Ridge\nfrom sklearn.metrics import mean_absolute_error\n\n# A\u00f1adir src/ al path para importar cfg\nPROJECT_ROOT = pathlib.Path().resolve().parents[1]\nif str(PROJECT_ROOT) not in sys.path:\n    sys.path.insert(0, str(PROJECT_ROOT))\n\nfrom src import config as cfg"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "# Cargar dataset procesado de XGB\ndf = joblib.load(cfg.DATA / 'processed' / 'xgb_data.pkl')\nprint(f'\u2705 Datos cargados: {len(df):,} muestras')\n\n# Separar train/test por fecha\nsplit_date = df['date'].quantile(0.8)\ndf_train = df[df['date'] <= split_date].copy()\ndf_test  = df[df['date'] > split_date].copy()\nprint(f'\ud83d\udcca Train: {len(df_train):,} | Test: {len(df_test):,}')"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "features = ['ret_1d','ret_5d','vol_5d','momentum']\nmodels = {}\nmae_scores = {}\nfor ticker in df['ticker'].unique():\n    tr = df_train[df_train['ticker'] == ticker]\n    te = df_test[df_test['ticker'] == ticker]\n    X_tr, y_tr = tr[features], tr['target_5d']\n    X_te, y_te = te[features], te['target_5d']\n    model = Ridge(alpha=1.0)\n    model.fit(X_tr, y_tr)\n    pred = model.predict(X_te)\n    mae = mean_absolute_error(y_te, pred)\n    models[ticker] = model\n    mae_scores[ticker] = mae\n    print(f'\u2705 {ticker:5} | MAE: {mae:.5f} | Train: {len(X_tr):4} | Test: {len(X_te):4}')"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "joblib.dump(models, cfg.MODELS / 'ridge.pkl')\nprint('\ud83d\udcbe Modelos guardados en models/ridge.pkl')"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/predict_ridge.py
+++ b/src/predict_ridge.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import numpy as np
+import joblib
+from src import config as cfg
+
+
+def predict_ridge(df_prices: pd.DataFrame, fecha: pd.Timestamp, tickers: list[str]) -> pd.Series:
+    """Predice retornos esperados a 5 d\u00edas usando modelos Ridge por ticker."""
+    modelos = joblib.load(cfg.MODELS / "ridge.pkl")
+
+    if fecha not in df_prices.index:
+        raise ValueError(f"La fecha {fecha} no est\u00e1 en el \u00edndice del dataframe")
+    idx = df_prices.index.get_loc(fecha)
+    if idx < 6:
+        raise ValueError("No hay suficientes d\u00edas anteriores para calcular features")
+
+    df_ret = np.log(df_prices / df_prices.shift(1))
+    df_ret5 = df_ret.rolling(5).sum()
+    df_vol5 = df_ret.rolling(5).std()
+    df_mom = (df_ret5 / (df_vol5 + 1e-6)).clip(-10, 10)
+
+    datos = []
+    for ticker in tickers:
+        try:
+            datos.append(
+                (
+                    ticker,
+                    [
+                        df_ret.loc[fecha, ticker],
+                        df_ret5.loc[fecha, ticker],
+                        df_vol5.loc[fecha, ticker],
+                        df_mom.loc[fecha, ticker],
+                    ],
+                )
+            )
+        except KeyError:
+            continue
+
+    if not datos:
+        return pd.Series(dtype=float)
+
+    X = pd.DataFrame([x[1] for x in datos], columns=["ret_1d", "ret_5d", "vol_5d", "momentum"])
+    tickers_ok = [x[0] for x in datos]
+
+    preds = []
+    for i, ticker in enumerate(tickers_ok):
+        model = modelos.get(ticker)
+        if model is not None:
+            pred = model.predict(X.iloc[[i]])[0]
+        else:
+            pred = np.nan
+        preds.append(pred)
+
+    return pd.Series(preds, index=tickers_ok, name="ret_esperado")


### PR DESCRIPTION
## Summary
- add notebook to train per-ticker Ridge models
- implement `predict_ridge` helper for inference

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c43e4d7cc832589f3a660e65ea40b