### PR TITLE
Add walk-forward evaluation notebook

### DIFF
--- a/notebooks/09_walk_forward.ipynb
+++ b/notebooks/09_walk_forward.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 09 Walk Forward\n",
+    "This notebook performs a walk-forward evaluation of the trading strategy.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, pathlib\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import joblib\n",
+    "from src import config as cfg\n",
+    "from src import evol_utils as eu\n",
+    "from tensorflow import keras\n",
+    "\n",
+    "PROJECT_ROOT = pathlib.Path().resolve().parent\n",
+    "if str(PROJECT_ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(PROJECT_ROOT))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load prices and features\n",
+    "df_prices = pd.read_parquet(cfg.DATA / 'raw' / 'prices.parquet').sort_index()\n",
+    "data = joblib.load(cfg.DATA / 'processed' / 'cnn5d_data.pkl')\n",
+    "tickers = data['tickers']\n",
+    "df_prices = df_prices[tickers]\n",
+    "df_ret = np.log(df_prices / df_prices.shift(1)).dropna()\n",
+    "ret5 = df_ret.rolling(5).sum()\n",
+    "vol5 = df_ret.rolling(5).std()\n",
+    "momentum = (ret5 / vol5).shift(1)\n",
+    "df_feat = pd.concat([df_ret.shift(1), momentum], axis=1).dropna()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _lazy_loader(var_name, pkl_path):\n",
+    "    if var_name not in globals():\n",
+    "        globals()[var_name] = joblib.load(pkl_path)\n",
+    "    return globals()[var_name]\n",
+    "\n",
+    "def rebalancear_en_fecha(fecha, df_feat, model, w_prev=None):\n",
+    "    try:\n",
+    "        idx = df_feat.index.get_loc(fecha)\n",
+    "        ventana = df_feat.iloc[idx - cfg.WINDOW: idx]\n",
+    "\n",
+    "        scaler_X = _lazy_loader('scaler_X_cnn5d', cfg.MODELS / 'scaler_X_cnn5d.pkl')\n",
+    "        X_scaled = scaler_X.transform(ventana.values)\n",
+    "        n_assets = len(tickers)\n",
+    "        X_input = X_scaled.reshape(1, cfg.WINDOW, n_assets, 2)\n",
+    "        r_hat = model.predict(X_input, verbose=0)[0]\n",
+    "        scaler_y = _lazy_loader('scaler_y_cnn5d', cfg.MODELS / 'scaler_y_cnn5d.pkl')\n",
+    "        r_hat = scaler_y.inverse_transform([r_hat])[0] / 5.0\n",
+    "        r_hat = np.clip(r_hat, -0.12, 0.12)\n",
+    "\n",
+    "        fecha_ret = df_feat.index[idx]\n",
+    "        ventana_ret = df_ret.loc[:fecha_ret - pd.Timedelta(days=1)].tail(cfg.WINDOW)\n",
+    "        Sigma = ventana_ret.cov().values\n",
+    "        res = eu.resolver_optimizacion(r_hat, Sigma, w_prev=w_prev)\n",
+    "        w_star = eu.elegir_w_star(res, r_hat, Sigma, w_prev=w_prev)\n",
+    "\n",
+    "        turnover = np.sum(np.abs(w_star - w_prev)) if w_prev is not None else 1.0\n",
+    "        ret_bruto = df_ret.iloc[idx: idx + cfg.REBAL_FREQ].values @ w_star\n",
+    "        ret_neto = ret_bruto.sum() - turnover * cfg.COST_TRADE\n",
+    "        ret_diarios = pd.Series(ret_bruto, index=df_ret.iloc[idx: idx + cfg.REBAL_FREQ].index)\n",
+    "\n",
+    "        return {\n",
+    "            'fecha': fecha,\n",
+    "            'ret_neto': ret_neto,\n",
+    "            'w_star': w_star,\n",
+    "            'ret_diarios': ret_diarios\n",
+    "        }\n",
+    "    except Exception as e:\n",
+    "        print(f'ERROR {fecha.date()}: {e}')\n",
+    "        return None\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Date ranges\n",
+    "periods = [\n",
+    "    ('2017-01-01', '2019-01-01'),\n",
+    "    ('2019-01-01', '2021-01-01'),\n",
+    "    ('2021-01-01', '2024-01-01')\n",
+    "]\n",
+    "\n",
+    "all_returns = []\n",
+    "w_prev = None\n",
+    "model = keras.models.load_model(cfg.MODELS / 'cnn5d.keras', compile=False)\n",
+    "\n",
+    "for start, end in periods:\n",
+    "    fechas = df_feat.loc[start:end].index\n",
+    "    for i in range(cfg.WINDOW, len(fechas) - cfg.REBAL_FREQ, cfg.REBAL_FREQ):\n",
+    "        fecha = fechas[i]\n",
+    "        out = rebalancear_en_fecha(fecha, df_feat, model, w_prev=w_prev)\n",
+    "        if out is not None:\n",
+    "            all_returns.append(out['ret_diarios'])\n",
+    "            w_prev = out['w_star']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "equity = (1 + pd.concat(all_returns)).cumprod()\n",
+    "equity.to_frame('equity').plot(figsize=(12,4))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create walk-forward evaluation notebook that splits the data
- sequentially rebalance over three time blocks and build an equity curve

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c43e6f4748325ac6e4fa5d25a0440